### PR TITLE
Sort files in chop test

### DIFF
--- a/tests/ChopTest.cs
+++ b/tests/ChopTest.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using NUnit.Framework;
 using System.IO;
 using CSVFile;
+using System.Linq;
 
 namespace CSVTestSuite
 {
@@ -56,7 +57,8 @@ namespace CSVTestSuite
 
             // Save this string to a test file
             string singlefile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".csv");
-            File.WriteAllText(singlefile, CSV.Serialize<SimpleChopClass>(list));
+            var rawcsv = CSV.Serialize<SimpleChopClass>(list);
+            File.WriteAllText(singlefile, rawcsv);
 
             // Create an empty test folder
             string dirname = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
@@ -66,7 +68,7 @@ namespace CSVTestSuite
             CSVReader.ChopFile(singlefile, dirname, 5000);
 
             // Verify that we got three files
-            string[] files = Directory.GetFiles(dirname);
+            string[] files = Directory.GetFiles(dirname).OrderBy(f => f).ToArray();
             Assert.AreEqual(3, files.Length);
 
             // Read in each file and verify that each one has one line


### PR DESCRIPTION
Looks like this test sometimes fails because the file names are not sorted when returned from Directory.GetFiles.

Let's fix this by applying LINQ.