### PR TITLE
Fix perf of newlines

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,27 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            // Use IntelliSense to find out which attributes exist for C# debugging
+            // Use hover for the description of the existing attributes
+            // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+            "name": ".NET Core Launch (console)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/tests/net50/bin/Debug/net5.0/tests.net50.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/tests/net50",
+            // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach",
+            "processId": "${command:pickProcess}"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,42 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/tests/net50/tests.net50.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/tests/net50/tests.net50.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "watch",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "${workspaceFolder}/tests/net50/tests.net50.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/src/CSV.cs
+++ b/src/CSV.cs
@@ -117,16 +117,21 @@ namespace CSVFile
                 {
                     // Our next task is to find the end of this qualified-text field
                     int p2 = -1;
-                    while (p2 < 0 && !inStream.EndOfStream) {
+                    while (p2 < 0) {
 
                         // If we don't see an end in sight, read more from the stream
                         p2 = line.IndexOf(settings.TextQualifier, i + 1);
                         if (p2 < 0) {
 
                             // No text qualifiers yet? Let's read more from the stream and continue
-                            work.Append(line);
+                            work.Append(line.Substring(i + 1));
                             i = -1;
-                            line = inStream.ReadLine() + settings.LineSeparator;
+                            var newLine = inStream.ReadLine();
+                            if (String.IsNullOrEmpty(newLine) && inStream.EndOfStream)
+                            {
+                                break;
+                            }
+                            line = newLine + settings.LineSeparator;
                             continue;
                         }
 

--- a/src/CSV.cs
+++ b/src/CSV.cs
@@ -61,6 +61,115 @@ namespace CSVFile
 
 #region Methods to read CSV data
         /// <summary>
+        /// Parse a CSV stream into IEnumerable<string[]>, while permitting embedded newlines
+        /// </summary>
+        /// <param name="inStream">The stream to read</param>
+        /// <param name="settings">The CSV settings to use for this parsing operation (Default: CSV)</param>
+        /// <returns>An enumerable object that can be examined to retrieve rows from the stream.</returns>
+        public static IEnumerable<string[]> ParseStream(StreamReader inStream, CSVSettings settings = null)
+        {
+            string line = "";
+            int i = -1;
+            List<string> list = new List<string>();
+            var work = new StringBuilder();
+
+            // Ensure settings are non-null
+            if (settings == null) {
+                settings = CSVSettings.CSV;
+            }
+
+            // Begin reading from the stream
+            while (i < line.Length || !inStream.EndOfStream)
+            {
+                // Consume the next character of data
+                i++;
+                if (i >= line.Length) {
+                    var newLine = inStream.ReadLine();
+                    line += newLine + settings.LineSeparator;
+                }
+                char c = line[i];
+
+                // Are we at a line separator? If so, yield our work and begin again
+                if (String.Equals(line.Substring(i, settings.LineSeparator.Length), settings.LineSeparator)) {
+                    list.Add(work.ToString());
+                    yield return list.ToArray();
+                    list.Clear();
+                    work.Clear();
+                    if (inStream.EndOfStream)
+                    {
+                        break;
+                    }
+
+                    // Read in next line
+                    if (i + settings.LineSeparator.Length >= line.Length)
+                    {
+                        line = inStream.ReadLine() + settings.LineSeparator;
+                    }
+                    else
+                    {
+                        line = line.Substring(i + settings.LineSeparator.Length);
+                    }
+                    i = -1;
+
+                    // While starting a field, do we detect a text qualifier?
+                }
+                else if ((c == settings.TextQualifier) && (work.Length == 0))
+                {
+                    // Our next task is to find the end of this qualified-text field
+                    int p2 = -1;
+                    while (p2 < 0 && !inStream.EndOfStream) {
+
+                        // If we don't see an end in sight, read more from the stream
+                        p2 = line.IndexOf(settings.TextQualifier, i + 1);
+                        if (p2 < 0) {
+
+                            // No text qualifiers yet? Let's read more from the stream and continue
+                            work.Append(line);
+                            i = -1;
+                            line = inStream.ReadLine() + settings.LineSeparator;
+                            continue;
+                        }
+
+                        // Append the text between the qualifiers
+                        work.Append(line.Substring(i + 1, p2 - i - 1));
+                        i = p2;
+                        
+                        // If the user put in a doubled-up qualifier, e.g. `""`, insert a single one and continue
+                        if (((p2 + 1) < line.Length) && (line[p2 + 1] == settings.TextQualifier))
+                        {
+                            work.Append(settings.TextQualifier);
+                            i++;
+                            p2 = -1;
+                            continue;
+                        }
+                    }
+
+                    // Does this start a new field?
+                }
+                else if (c == settings.FieldDelimiter)
+                {
+                    // Is this a null token, and do we permit null tokens?
+                    AddToken(list, work, settings);
+
+                    // Test for special case: when the user has written a casual comma, space, and text qualifier, skip the space
+                    // Checks if the second parameter of the if statement will pass through successfully
+                    // e.g. `"bob", "mary", "bill"`
+                    if (i + 2 <= line.Length - 1)
+                    {
+                        if (line[i + 1].Equals(' ') && line[i + 2].Equals(settings.TextQualifier))
+                        {
+                            i++;
+                        }
+                    }
+                }
+                else
+                {
+                    work.Append(c);
+                }
+            }
+        }
+
+        /// <summary>
         /// Parse a single row of data from a CSV line into an array of objects, while permitting embedded newlines
         /// </summary>
         /// <param name="inStream">The stream to read</param>
@@ -181,9 +290,9 @@ namespace CSVFile
                     work.Append(c);
                 }
             }
-            AddToken(list, work, settings);
 
-            // Return the array we parsed
+            // We always add the last work as an element.  That means `alice,bob,charlie,` will be four items long.
+            AddToken(list, work, settings);
             row = list.ToArray();
             return true;
         }

--- a/src/CSVReader.cs
+++ b/src/CSVReader.cs
@@ -77,22 +77,12 @@ namespace CSVFile
         /// <returns>An array of all data columns in the line</returns>
         public IEnumerable<string[]> Lines()
         {
-            while (true)
-            {
-
-                // Attempt to parse the line successfully
-                string[] line = NextLine();
-
-                // If we were unable to parse the line successfully, that's all the file has
-                if (line == null) break;
-
-                // We got something - give the caller an object
-                yield return line;
-            }
+            return CSV.ParseStream(_instream, _settings);
         }
 
         /// <summary>
         /// Retrieve the next line from the file.
+        /// DEPRECATED - 
         /// </summary>
         /// <returns>One line from the file.</returns>
         public string[] NextLine()

--- a/tests/ChopTest.cs
+++ b/tests/ChopTest.cs
@@ -97,7 +97,8 @@ namespace CSVTestSuite
             Directory.Delete(dirname, true);
             File.Delete(singlefile);
         }
-        /*
+
+#if HAS_DATATABLE
         [Test]
         public void DataTableChoppingFiles()
         {
@@ -105,7 +106,7 @@ namespace CSVTestSuite
 2012-05-01,test1,""Hi there, I said!"",Bob,57,0
 2011-04-01,test2,""What's up, buttercup?"",Ralph,1,-999
 1975-06-03,test3,""Bye and bye, dragonfly!"",Jimmy's The Bomb,12,13";
-            DataTable dt = CSVDataTable.FromString(source);
+            var dt = CSVDataTable.FromString(source);
 
             // Save this string to a test file
             string test_rootfn = Guid.NewGuid().ToString();
@@ -142,6 +143,7 @@ namespace CSVTestSuite
             // Clean up
             Directory.Delete(dirname, true);
             File.Delete(outfile);
-        }*/
+        }
+#endif
     }
 }

--- a/tests/ReaderTest.cs
+++ b/tests/ReaderTest.cs
@@ -57,6 +57,9 @@ namespace CSVTestSuite
                             Assert.AreEqual(line[0], "Dr. Kelso");
                             Assert.AreEqual(line[1], "Chief of Medicine");
                             Assert.AreEqual(line[2], "x100");
+                        } else
+                        {
+                            Assert.IsTrue(false, "Should not get here");
                         }
                         i++;
                     }

--- a/tests/ReaderTest.cs
+++ b/tests/ReaderTest.cs
@@ -37,6 +37,7 @@ namespace CSVTestSuite
                 using (CSVReader cr = new CSVReader(sr, settings)) {
                     int i = 0;
                     foreach (string[] line in cr) {
+                        Assert.AreEqual(3, line.Length);
                         if (i == 0) {
                             Assert.AreEqual(line[0], "Name");
                             Assert.AreEqual(line[1], "Title");
@@ -57,6 +58,71 @@ namespace CSVTestSuite
                             Assert.AreEqual(line[0], "Dr. Kelso");
                             Assert.AreEqual(line[1], "Chief of Medicine");
                             Assert.AreEqual(line[2], "x100");
+                        } else
+                        {
+                            Assert.IsTrue(false, "Should not get here");
+                        }
+                        i++;
+                    }
+                }
+            }
+        }
+
+
+        [Test]
+        public void TestDanglingFields()
+        {
+            string source = "Name,Title,Phone,Dangle\n" +
+                "JD,Doctor,x234,\n" +
+                "Janitor,Janitor,x235,\n" +
+                "\"Dr. Reed, " + Environment.NewLine + "Eliot\",\"Private \"\"Practice\"\"\",x236,\n" +
+                "Dr. Kelso,Chief of Medicine,x100,\n" +
+                ",,,";
+
+            // Skip header row
+            CSVSettings settings = new CSVSettings()
+            {
+                HeaderRowIncluded = false
+            };
+
+            // Convert into stream
+            byte[] byteArray = Encoding.UTF8.GetBytes(source);
+            MemoryStream stream = new MemoryStream(byteArray);
+            using (StreamReader sr = new StreamReader(stream)) {
+                using (CSVReader cr = new CSVReader(sr, settings)) {
+                    int i = 0;
+                    foreach (string[] line in cr) {
+                        Assert.AreEqual(4, line.Length);
+                        if (i == 0) {
+                            Assert.AreEqual(line[0], "Name");
+                            Assert.AreEqual(line[1], "Title");
+                            Assert.AreEqual(line[2], "Phone");
+                            Assert.AreEqual(line[3], "Dangle");
+                        } else if (i == 1) {
+                            Assert.AreEqual(line[0], "JD");
+                            Assert.AreEqual(line[1], "Doctor");
+                            Assert.AreEqual(line[2], "x234");
+                            Assert.AreEqual(line[3], "");
+                        } else if (i == 2) {
+                            Assert.AreEqual(line[0], "Janitor");
+                            Assert.AreEqual(line[1], "Janitor");
+                            Assert.AreEqual(line[2], "x235");
+                            Assert.AreEqual(line[3], "");
+                        } else if (i == 3) {
+                            Assert.AreEqual(line[0], "Dr. Reed, " + Environment.NewLine + "Eliot");
+                            Assert.AreEqual(line[1], "Private \"Practice\"");
+                            Assert.AreEqual(line[2], "x236");
+                            Assert.AreEqual(line[3], "");
+                        } else if (i == 4) {
+                            Assert.AreEqual(line[0], "Dr. Kelso");
+                            Assert.AreEqual(line[1], "Chief of Medicine");
+                            Assert.AreEqual(line[2], "x100");
+                            Assert.AreEqual(line[3], "");
+                        } else if (i == 5) {
+                            Assert.AreEqual(line[0], "");
+                            Assert.AreEqual(line[1], "");
+                            Assert.AreEqual(line[2], "");
+                            Assert.AreEqual(line[3], "");
                         } else
                         {
                             Assert.IsTrue(false, "Should not get here");


### PR DESCRIPTION
As per #21 , @ronnieoverby discovered that the "embedded newline" code that I created was ... shall we say ... terrible.

It was partially acceptable only if your CSV files had virtually no embedded newlines.  If you had lots of embedded newlines, the code would execute tons of backtracking and reparsing, which would bog down the scenario really badly.

This code implements a proper read-from-stream system which does no backtracking and only looks forward.

As demonstrated by Ronnie's test program, the new solution reads the results in 132ms.

```
Starting at 3/30/2021 4:27:08 PM
Beginning to read lines at 3/30/2021 4:27:09 PM
Line count: 10
Line count: 20
Line count: 30
Line count: 40
Line count: 50
Line count: 60
Line count: 70
Line count: 80
Line count: 90
Line count: 100
Line count: 110
Finished reading 113 lines in 132.6835ms
```