### PR TITLE
Tests for deserialize a nullable floating point value 

### DIFF
--- a/src/CSVDataTable.cs
+++ b/src/CSVDataTable.cs
@@ -69,6 +69,8 @@ namespace CSVFile
         /// <param name="to_address"></param>
         /// <param name="subject"></param>
         /// <param name="body"></param>
+        /// <param name="smtp_host"></param>
+        /// <param name="attachment_filename"></param>
 #if NET20
         public static void SendCsvAttachment(DataTable dt, string from_address, string to_address, string subject, string body, string smtp_host, string attachment_filename)
 #else

--- a/src/CSVDataTable.cs
+++ b/src/CSVDataTable.cs
@@ -113,7 +113,7 @@ namespace CSVFile
         public static void WriteToFile(this DataTable dt, string filename, CSVSettings settings = null)
 #endif
         {
-            using (StreamWriter sw = new StreamWriter(filename))
+            using (var sw = new StreamWriter(filename))
             {
                 WriteToStream(dt, sw, settings);
             }
@@ -131,7 +131,7 @@ namespace CSVFile
         public static void WriteToStream(this DataTable dt, StreamWriter sw, CSVSettings settings = null)
 #endif
         {
-            using (CSVWriter cw = new CSVWriter(sw, settings))
+            using (var cw = new CSVWriter(sw, settings))
             {
                 cw.Write(dt);
             }

--- a/src/CSVReader.cs
+++ b/src/CSVReader.cs
@@ -247,6 +247,11 @@ namespace CSVFile
             var row_num = 1;
             await foreach (var line in this)
             {
+                // If this line is completely empty, do our settings permit us to ignore the empty line?
+                if (line.Length == 0 || (line.Length == 1 && line[0] == String.Empty) && _settings.IgnoreEmptyLineForDeserialization)
+                {
+                    continue;
+                }
 
                 // Does this line match the length of the first line?  Does the caller want us to complain?
                 if ((line.Length != num_columns) && !_settings.IgnoreHeaderErrors)
@@ -451,9 +456,14 @@ namespace CSVFile
             var row_num = 1;
             foreach (var line in CSV.ParseStream(_stream, _settings))
             {
+                // If this line is completely empty, do our settings permit us to ignore the empty line?
+                if (line.Length == 0 || (line.Length == 1 && line[0] == String.Empty) && _settings.IgnoreEmptyLineForDeserialization)
+                {
+                    continue;
+                }
 
                 // Does this line match the length of the first line?  Does the caller want us to complain?
-                if ((line.Length != num_columns) && !_settings.IgnoreHeaderErrors) {
+                if (line.Length != num_columns && !_settings.IgnoreHeaderErrors) {
                     throw new Exception($"Line #{row_num} contains {line.Length} columns; expected {num_columns}");
                 }
 

--- a/src/CSVReader.cs
+++ b/src/CSVReader.cs
@@ -248,7 +248,7 @@ namespace CSVFile
             await foreach (var line in this)
             {
                 // If this line is completely empty, do our settings permit us to ignore the empty line?
-                if (line.Length == 0 || (line.Length == 1 && line[0] == String.Empty) && _settings.IgnoreEmptyLineForDeserialization)
+                if (line.Length == 0 || (line.Length == 1 && line[0] == string.Empty) && _settings.IgnoreEmptyLineForDeserialization)
                 {
                     continue;
                 }
@@ -263,10 +263,13 @@ namespace CSVFile
                 var obj = new T();
                 for (var i = 0; i < Math.Min(line.Length, num_columns); i++)
                 {
-
                     // Attempt to convert this to the specified type
                     object value = null;
-                    if (column_convert[i] != null && column_convert[i].IsValid(line[i]))
+                    if (_settings.AllowNull && (line[i] == null || line[i] == _settings.NullToken))
+                    {
+                        value = null;
+                    } 
+                    else if (column_convert[i] != null && column_convert[i].IsValid(line[i]))
                     {
                         value = column_convert[i].ConvertFromString(line[i]);
                     }
@@ -274,7 +277,7 @@ namespace CSVFile
                     {
                         throw new Exception($"The value '{line[i]}' cannot be converted to the type {column_types[i]}.");
                     }
-                     
+
                     // Can we set this value to the object as a property?
                     if (prop_handlers[i] != null)
                     {
@@ -290,7 +293,7 @@ namespace CSVFile
                     }
                     else if (method_handlers[i] != null)
                     {
-                        method_handlers[i].Invoke(obj, new[] { value });
+                        method_handlers[i].Invoke(obj, new object[] { value });
                     }
                 }
 

--- a/src/CSVSettings.cs
+++ b/src/CSVSettings.cs
@@ -94,6 +94,12 @@ namespace CSVFile
         /// Expect headers to be case sensitive during deserialization
         /// </summary>
         public bool HeadersCaseSensitive { get; set; }
+        
+        /// <summary>
+        /// Some CSV files contain an empty line at the end. If you set this flag to true, deserialization will
+        /// not throw an error for empty lines and will instead ignore it.
+        /// </summary>
+        public bool IgnoreEmptyLineForDeserialization { get; set; }
 
         /// <summary>
         /// Standard comma-separated value (CSV) file settings

--- a/tests/SerializationTest.cs
+++ b/tests/SerializationTest.cs
@@ -242,7 +242,7 @@ namespace CSVTestSuite
         
 #if HAS_ASYNC
         [Test]
-        public void DeserializeLastColumnNullableSingleAsync()
+        public async Task DeserializeLastColumnNullableSingleAsync()
         {
             var csv = "TestString,IntProperty,NullableSingle\n" +
                       "Test String,57,12.35\n" +
@@ -257,28 +257,8 @@ namespace CSVTestSuite
             settings.NullToken = string.Empty;
             settings.IgnoreEmptyLineForDeserialization = true;
 
-            // Deserialize back from a CSV string - should not throw any errors!
-            var list = CSV.Deserialize<TestClassLastColumnNullableSingle>(csv, settings).ToList();
-            Assert.AreEqual(4, list.Count);
-
-            Assert.AreEqual("Test String", list[0].TestString);
-            Assert.AreEqual(57, list[0].IntProperty);
-            Assert.AreEqual(12.35f, list[0].NullableSingle);
-            
-            Assert.AreEqual("Test String", list[1].TestString);
-            Assert.AreEqual(57, list[1].IntProperty);
-            Assert.IsNull(list[1].NullableSingle);
-            
-            Assert.AreEqual("Test String", list[2].TestString);
-            Assert.AreEqual(57, list[2].IntProperty);
-            Assert.AreEqual(56.19f, list[2].NullableSingle);
-
-            Assert.AreEqual("Test String", list[3].TestString);
-            Assert.AreEqual(57, list[3].IntProperty);
-            Assert.IsNull(list[3].NullableSingle);
-        
-            // Try again, this time with async
-            list = await CSV.DeserializeAsync<TestClassLastColumnNullableSingle>(csv, settings).ToList();
+            // Try deserializing using the async version
+            var list = await CSV.DeserializeAsync<TestClassLastColumnNullableSingle>(csv, settings).ToListAsync();
             Assert.AreEqual(4, list.Count);
 
             Assert.AreEqual("Test String", list[0].TestString);

--- a/tests/SerializationTest.cs
+++ b/tests/SerializationTest.cs
@@ -195,5 +195,108 @@ namespace CSVTestSuite
             // Did an empty field get imported as an empty string?
             Assert.AreEqual("", list[4].FirstColumn);
         }
+
+        public class TestClassLastColumnNullableSingle
+        {
+            public string TestString;
+            public int IntProperty { get; set; }
+            public float? NullableSingle { get; set; }
+        }
+        
+        [Test]
+        public void DeserializeLastColumnNullableSingle()
+        {
+            var csv = "TestString,IntProperty,NullableSingle\n" +
+                      "Test String,57,12.35\n" +
+                      "Test String,57,\n" +
+                      "Test String,57,56.19\n" + 
+                      "Test String,57,\n" +
+                      "\n";
+            
+            // Let's specifically allow null
+            var settings = new CSVSettings();
+            settings.AllowNull = true;
+            settings.NullToken = string.Empty;
+            settings.IgnoreEmptyLineForDeserialization = true;
+
+            // Deserialize back from a CSV string - should not throw any errors!
+            var list = CSV.Deserialize<TestClassLastColumnNullableSingle>(csv, settings).ToList();
+            Assert.AreEqual(4, list.Count);
+
+            Assert.AreEqual("Test String", list[0].TestString);
+            Assert.AreEqual(57, list[0].IntProperty);
+            Assert.AreEqual(12.35f, list[0].NullableSingle);
+            
+            Assert.AreEqual("Test String", list[1].TestString);
+            Assert.AreEqual(57, list[1].IntProperty);
+            Assert.IsNull(list[1].NullableSingle);
+            
+            Assert.AreEqual("Test String", list[2].TestString);
+            Assert.AreEqual(57, list[2].IntProperty);
+            Assert.AreEqual(56.19f, list[2].NullableSingle);
+
+            Assert.AreEqual("Test String", list[3].TestString);
+            Assert.AreEqual(57, list[3].IntProperty);
+            Assert.IsNull(list[3].NullableSingle);
+        }
+        
+#if HAS_ASYNC
+        [Test]
+        public void DeserializeLastColumnNullableSingleAsync()
+        {
+            var csv = "TestString,IntProperty,NullableSingle\n" +
+                      "Test String,57,12.35\n" +
+                      "Test String,57,\n" +
+                      "Test String,57,56.19\n" + 
+                      "Test String,57,\n" +
+                      "\n";
+            
+            // Let's specifically allow null
+            var settings = new CSVSettings();
+            settings.AllowNull = true;
+            settings.NullToken = string.Empty;
+            settings.IgnoreEmptyLineForDeserialization = true;
+
+            // Deserialize back from a CSV string - should not throw any errors!
+            var list = CSV.Deserialize<TestClassLastColumnNullableSingle>(csv, settings).ToList();
+            Assert.AreEqual(4, list.Count);
+
+            Assert.AreEqual("Test String", list[0].TestString);
+            Assert.AreEqual(57, list[0].IntProperty);
+            Assert.AreEqual(12.35f, list[0].NullableSingle);
+            
+            Assert.AreEqual("Test String", list[1].TestString);
+            Assert.AreEqual(57, list[1].IntProperty);
+            Assert.IsNull(list[1].NullableSingle);
+            
+            Assert.AreEqual("Test String", list[2].TestString);
+            Assert.AreEqual(57, list[2].IntProperty);
+            Assert.AreEqual(56.19f, list[2].NullableSingle);
+
+            Assert.AreEqual("Test String", list[3].TestString);
+            Assert.AreEqual(57, list[3].IntProperty);
+            Assert.IsNull(list[3].NullableSingle);
+        
+            // Try again, this time with async
+            list = await CSV.DeserializeAsync<TestClassLastColumnNullableSingle>(csv, settings).ToList();
+            Assert.AreEqual(4, list.Count);
+
+            Assert.AreEqual("Test String", list[0].TestString);
+            Assert.AreEqual(57, list[0].IntProperty);
+            Assert.AreEqual(12.35f, list[0].NullableSingle);
+            
+            Assert.AreEqual("Test String", list[1].TestString);
+            Assert.AreEqual(57, list[1].IntProperty);
+            Assert.IsNull(list[1].NullableSingle);
+            
+            Assert.AreEqual("Test String", list[2].TestString);
+            Assert.AreEqual(57, list[2].IntProperty);
+            Assert.AreEqual(56.19f, list[2].NullableSingle);
+
+            Assert.AreEqual("Test String", list[3].TestString);
+            Assert.AreEqual(57, list[3].IntProperty);
+            Assert.IsNull(list[3].NullableSingle);
+        }
+#endif
     }
 }

--- a/tests/net50/tests.net50.csproj
+++ b/tests/net50/tests.net50.csproj
@@ -11,6 +11,10 @@
     <DefineConstants>TRACE;NET50;HAS_DATATABLE;HAS_ASYNC;</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <DefineConstants>TRACE;HAS_ASYNC;</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="..\AsyncReaderTest.cs" Link="AsyncReaderTest.cs" />
     <Compile Include="..\BasicParseTests.cs" Link="BasicParseTests.cs" />
@@ -25,6 +29,7 @@
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/netstandard20/tests.netstandard20.csproj
+++ b/tests/netstandard20/tests.netstandard20.csproj
@@ -19,7 +19,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;NETSTANDARD20;HAS_DATATABLE;HAS_ASYNC;</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NETSTANDARD20;HAS_DATATABLE;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -27,7 +27,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE;NETSTANDARD20;HAS_DATATABLE;HAS_ASYNC;</DefineConstants>
+    <DefineConstants>TRACE;NETSTANDARD20;HAS_DATATABLE;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>


### PR DESCRIPTION
As per #38 we have reports that an empty string deserialized into a nullable floating point value at the end of a string fails with a type conversion error.

It seems like this should work if you set `AllowNull = true` and `NullToken = String.Empty`. Let's test.