### PR TITLE
Fix all #if statements and flags

### DIFF
--- a/src/CSV.cs
+++ b/src/CSV.cs
@@ -7,7 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
-#if NET50
+#if HAS_ASYNC
 using System.Threading.Tasks;
 #endif
 
@@ -30,15 +30,15 @@ namespace CSVFile
         /// <summary>
         /// Use this to determine what version of DotNet was used to build this library
         /// </summary>
-#if NET20
+#if NET2_0
         public const string VERSION = "NET20";
-#elif NET40
+#elif NET4_0
         public const string VERSION = "NET40";
-#elif NET45
+#elif NET4_5
         public const string VERSION = "NET45";
-#elif NET50
+#elif NET5_0
         public const string VERSION = "NET50";
-#elif NET60
+#elif NET6_0
         public const string VERSION = "NET60";
 #elif NETSTANDARD1_0
         public const string VERSION = "NETSTANDARD10";
@@ -196,7 +196,7 @@ namespace CSVFile
             }
         }
 
-#if NET50
+#if HAS_ASYNC_IENUM
         /// <summary>
         /// Parse a CSV stream into <![CDATA[ IEnumerable<string[]> ]]> asynchronously, while permitting embedded newlines
         /// </summary>
@@ -467,7 +467,7 @@ namespace CSVFile
             return CSVReader.FromString(source, settings).Deserialize<T>();
         }
 
-#if NET50
+#if HAS_ASYNC_IENUM
         /// <summary>
         /// Deserialize a CSV string into a list of typed objects
         /// </summary>
@@ -487,7 +487,7 @@ namespace CSVFile
         /// <returns>A single line of CSV encoded data containing these values</returns>
         /// <param name="row">A list or array of objects to serialize</param>
         /// <param name="settings">The field delimiter character (Default: comma)</param>
-#if NET20
+#if NET2_0
         public static string ToCSVString(IEnumerable<object> row, CSVSettings settings = null)
 #else
         public static string ToCSVString(this IEnumerable<object> row, CSVSettings settings = null)
@@ -532,7 +532,7 @@ namespace CSVFile
         /// </summary>
         /// <param name="sb">The StringBuilder to append data</param>
         /// <param name="settings">The CSV settings to use when exporting this array (Default: CSV)</param>
-#if NET20
+#if NET2_0
         public static void AppendCSVHeader<T>(StringBuilder sb, CSVSettings settings = null)
 #else
         public static void AppendCSVHeader<T>(this StringBuilder sb, CSVSettings settings = null)
@@ -565,7 +565,7 @@ namespace CSVFile
         /// <param name="obj">The single object to append in CSV-line format</param>
         /// <param name="settings">The CSV settings to use when exporting this array (Default: CSV)</param>
         /// <typeparam name="T">The 1st type parameter.</typeparam>
-#if NET20
+#if NET2_0
         public static void AppendCSVLine<T>(StringBuilder sb, T obj, CSVSettings settings = null) where T : class, new()
 #else
         public static void AppendCSVLine<T>(this StringBuilder sb, T obj, CSVSettings settings = null) where T : class, new()
@@ -599,7 +599,7 @@ namespace CSVFile
         /// <param name="sb">The StringBuilder to append</param>
         /// <param name="row">The list of objects to append</param>
         /// <param name="settings">The CSV settings to use when exporting this array (Default: CSV)</param>
-#if NET20
+#if NET2_0
         private static void AppendCSVRow(StringBuilder sb, IEnumerable<object> row, CSVSettings settings = null)
 #else
         private static void AppendCSVRow(this StringBuilder sb, IEnumerable<object> row, CSVSettings settings = null)

--- a/src/CSVDataTable.cs
+++ b/src/CSVDataTable.cs
@@ -60,7 +60,6 @@ namespace CSVFile
             }
         }
 
-#if HAS_SMTPCLIENT
         /// <summary>
         /// Quick shortcut to send a datatable as an attachment via SMTP
         /// </summary>
@@ -101,7 +100,6 @@ namespace CSVFile
             }
 #endif
         }
-#endif
 
         /// <summary>
         /// Write a data table to disk at the designated file name in CSV format

--- a/src/CSVDataTable.cs
+++ b/src/CSVDataTable.cs
@@ -71,7 +71,7 @@ namespace CSVFile
         /// <param name="body"></param>
         /// <param name="smtp_host"></param>
         /// <param name="attachment_filename"></param>
-#if NET20
+#if NET2_0
         public static void SendCsvAttachment(DataTable dt, string from_address, string to_address, string subject, string body, string smtp_host, string attachment_filename)
 #else
         public static void SendCsvAttachment(this DataTable dt, string from_address, string to_address, string subject, string body, string smtp_host, string attachment_filename)
@@ -90,7 +90,7 @@ namespace CSVFile
             a.Name = attachment_filename;
             message.Attachments.Add(a);
 
-#if NET20
+#if NET2_0
             // In DotNet 2.0, SmtpClient isn't disposable
             var smtp = new System.Net.Mail.SmtpClient(smtp_host);
             smtp.Send(message);
@@ -109,7 +109,7 @@ namespace CSVFile
         /// <param name="dt"></param>
         /// <param name="filename"></param>
         /// <param name="settings">The CSV settings to use when exporting this DataTable (Default: CSV)</param>
-#if NET20
+#if NET2_0
         public static void WriteToFile(DataTable dt, string filename, CSVSettings settings = null)
 #else
         public static void WriteToFile(this DataTable dt, string filename, CSVSettings settings = null)
@@ -127,7 +127,7 @@ namespace CSVFile
         /// <param name="dt">The data table to write</param>
         /// <param name="sw">The stream where the CSV text will be written</param>
         /// <param name="settings">The CSV settings to use when exporting this DataTable (Default: CSV)</param>
-#if NET20
+#if NET2_0
         public static void WriteToStream(DataTable dt, StreamWriter sw, CSVSettings settings = null)
 #else
         public static void WriteToStream(this DataTable dt, StreamWriter sw, CSVSettings settings = null)
@@ -145,7 +145,7 @@ namespace CSVFile
         /// <param name="dt">The datatable to write</param>
         /// <param name="settings">The CSV settings to use when exporting this DataTable (Default: CSV)</param>
         /// <returns>The CSV string representing the object array.</returns>
-#if NET20
+#if NET2_0
         public static string WriteToString(DataTable dt, CSVSettings settings = null)
 #else
         public static string WriteToString(this DataTable dt, CSVSettings settings = null)

--- a/src/CSVReader.cs
+++ b/src/CSVReader.cs
@@ -14,7 +14,7 @@ using System.Reflection;
 using System.ComponentModel;
 using System.Text;
 using System.Threading;
-#if NET50
+#if HAS_ASYNC
 using System.Threading.Tasks;
 #endif
 
@@ -30,7 +30,7 @@ namespace CSVFile
     /// <summary>
     /// A reader that reads from a stream and emits CSV records
     /// </summary>
-#if NET50
+#if HAS_ASYNC_IENUM
     public class CSVReader : IAsyncEnumerable<string[]>, IEnumerable<string[]>, IDisposable
 #else
     public class CSVReader : IEnumerable<string[]>, IDisposable
@@ -149,7 +149,7 @@ namespace CSVFile
             return GetEnumerator();
         }
         
-#if NET50
+#if HAS_ASYNC_IENUM
         /// <summary>
         /// Iterate through all lines in this CSV file using async
         /// </summary>

--- a/src/CSVReader.cs
+++ b/src/CSVReader.cs
@@ -7,9 +7,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
-#if HAS_DATATABLE
 using System.Data;
-#endif
 using System.Reflection;
 using System.ComponentModel;
 using System.Text;
@@ -193,7 +191,6 @@ namespace CSVFile
 #endif
 
 
-#if HAS_DATATABLE
         /// <summary>
         /// Read this file into a data table in memory
         /// </summary>
@@ -259,7 +256,6 @@ namespace CSVFile
             // Here's your data table
             return dt;
         }
-#endif
 
         /// <summary>
         /// Deserialize the CSV reader into a generic list

--- a/src/CSVWriter.cs
+++ b/src/CSVWriter.cs
@@ -7,9 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.IO;
-#if HAS_DATATABLE
 using System.Data;
-#endif
 using System.Reflection;
 
 namespace CSVFile
@@ -46,7 +44,6 @@ namespace CSVFile
             _stream.WriteLine(CSV.ToCSVString(line, _settings));
         }
 
-#if HAS_DATATABLE
         /// <summary>
         /// Write the data table to a stream in CSV format
         /// </summary>
@@ -70,7 +67,6 @@ namespace CSVFile
             // Flush the stream
             _stream.Flush();
         }
-#endif
 
         /// <summary>
         /// Serialize a list of objects to CSV using this writer

--- a/src/net20/src.net20.csproj
+++ b/src/net20/src.net20.csproj
@@ -19,14 +19,14 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\net20\</OutputPath>
-    <DefineConstants>DEBUG;NET2_0;HAS_DATATABLE;HAS_SMTPCLIENT</DefineConstants>
+    <DefineConstants>DEBUG;NET2_0</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\net20\</OutputPath>
-    <DefineConstants>NET2_0;HAS_DATATABLE;HAS_SMTPCLIENT</DefineConstants>
+    <DefineConstants>NET2_0</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\net20\src.net20.xml</DocumentationFile>

--- a/src/net20/src.net20.csproj
+++ b/src/net20/src.net20.csproj
@@ -19,14 +19,14 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\net20\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;NET20;HAS_DATATABLE;HAS_SMTPCLIENT</DefineConstants>
+    <DefineConstants>DEBUG;NET2_0;HAS_DATATABLE;HAS_SMTPCLIENT</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\net20\</OutputPath>
-    <DefineConstants>TRACE;NET20;HAS_DATATABLE;HAS_SMTPCLIENT</DefineConstants>
+    <DefineConstants>NET2_0;HAS_DATATABLE;HAS_SMTPCLIENT</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\net20\src.net20.xml</DocumentationFile>

--- a/src/net40/src.net40.csproj
+++ b/src/net40/src.net40.csproj
@@ -19,14 +19,14 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\net40\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;NET40;HAS_DATATABLE;HAS_SMTPCLIENT</DefineConstants>
+    <DefineConstants>DEBUG;NET4_0;HAS_DATATABLE;HAS_SMTPCLIENT</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\net40\</OutputPath>
-    <DefineConstants>TRACE;NET40;HAS_DATATABLE;HAS_SMTPCLIENT</DefineConstants>
+    <DefineConstants>NET4_0;HAS_DATATABLE;HAS_SMTPCLIENT</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\net40\src.net40.xml</DocumentationFile>

--- a/src/net40/src.net40.csproj
+++ b/src/net40/src.net40.csproj
@@ -19,14 +19,14 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\net40\</OutputPath>
-    <DefineConstants>DEBUG;NET4_0;HAS_DATATABLE;HAS_SMTPCLIENT</DefineConstants>
+    <DefineConstants>DEBUG;NET4_0</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\net40\</OutputPath>
-    <DefineConstants>NET4_0;HAS_DATATABLE;HAS_SMTPCLIENT</DefineConstants>
+    <DefineConstants>NET4_0</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\net40\src.net40.xml</DocumentationFile>

--- a/src/net45/src.net45.csproj
+++ b/src/net45/src.net45.csproj
@@ -19,14 +19,14 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\net45\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;NET45;HAS_DATATABLE;HAS_ASYNC;</DefineConstants>
+    <DefineConstants>DEBUG;NET4_5;HAS_DATATABLE;HAS_ASYNC;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\net45\</OutputPath>
-    <DefineConstants>TRACE;NET45;HAS_DATATABLE;HAS_ASYNC;</DefineConstants>
+    <DefineConstants>NET4_5;HAS_DATATABLE;HAS_ASYNC;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\net45\src.net45.xml</DocumentationFile>

--- a/src/net45/src.net45.csproj
+++ b/src/net45/src.net45.csproj
@@ -19,14 +19,14 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\net45\</OutputPath>
-    <DefineConstants>DEBUG;NET4_5;HAS_DATATABLE;HAS_ASYNC;</DefineConstants>
+    <DefineConstants>DEBUG;NET4_5;HAS_ASYNC;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\net45\</OutputPath>
-    <DefineConstants>NET4_5;HAS_DATATABLE;HAS_ASYNC;</DefineConstants>
+    <DefineConstants>NET4_5;HAS_ASYNC;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\net45\src.net45.xml</DocumentationFile>

--- a/src/net50/src.net50.csproj
+++ b/src/net50/src.net50.csproj
@@ -8,11 +8,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DefineConstants>TRACE;NET50;HAS_DATATABLE;HAS_ASYNC;</DefineConstants>
+    <DefineConstants>HAS_DATATABLE;HAS_ASYNC;HAS_ASYNC_IENUM;</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DefineConstants>TRACE;NET50;HAS_DATATABLE;HAS_ASYNC;</DefineConstants>
+    <DefineConstants>HAS_DATATABLE;HAS_ASYNC;HAS_ASYNC_IENUM;</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/net50/src.net50.csproj
+++ b/src/net50/src.net50.csproj
@@ -8,11 +8,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DefineConstants>HAS_DATATABLE;HAS_ASYNC;HAS_ASYNC_IENUM;</DefineConstants>
+    <DefineConstants>HAS_ASYNC;HAS_ASYNC_IENUM;</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DefineConstants>HAS_DATATABLE;HAS_ASYNC;HAS_ASYNC_IENUM;</DefineConstants>
+    <DefineConstants>HAS_ASYNC;HAS_ASYNC_IENUM;</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/netstandard20/src.netstandard20.csproj
+++ b/src/netstandard20/src.netstandard20.csproj
@@ -8,10 +8,10 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DefineConstants>TRACE20;HAS_ASYNC;HAS_DATATABLE;</DefineConstants>
+    <DefineConstants>HAS_ASYNC;HAS_DATATABLE;</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DefineConstants>TRACE20;HAS_ASYNC;HAS_DATATABLE;</DefineConstants>
+    <DefineConstants>HAS_ASYNC;HAS_DATATABLE;</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\CSV.cs">

--- a/src/netstandard20/src.netstandard20.csproj
+++ b/src/netstandard20/src.netstandard20.csproj
@@ -8,10 +8,10 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DefineConstants>HAS_ASYNC;HAS_DATATABLE;</DefineConstants>
+    <DefineConstants>HAS_ASYNC;</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DefineConstants>HAS_ASYNC;HAS_DATATABLE;</DefineConstants>
+    <DefineConstants>HAS_ASYNC;</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\CSV.cs">

--- a/tests/ChopTest.cs
+++ b/tests/ChopTest.cs
@@ -98,7 +98,6 @@ namespace CSVTestSuite
             File.Delete(singlefile);
         }
 
-#if HAS_DATATABLE
         [Test]
         public void DataTableChoppingFiles()
         {
@@ -151,6 +150,5 @@ namespace CSVTestSuite
             Directory.Delete(dirname, true);
             File.Delete(outfile);
         }
-#endif
     }
 }

--- a/tests/DataTableReaderTest.cs
+++ b/tests/DataTableReaderTest.cs
@@ -14,7 +14,6 @@ using System.Linq;
 
 namespace CSVTestSuite
 {
-#if HAS_DATATABLE
     [TestFixture]
     public class DataTableReaderTest
     {
@@ -178,5 +177,4 @@ namespace CSVTestSuite
             File.Delete(outfile);
         }
     }
-#endif
 }

--- a/tests/ReaderTest.cs
+++ b/tests/ReaderTest.cs
@@ -8,7 +8,7 @@ using System.Collections;
 using System.Collections.Generic;
 using NUnit.Framework;
 using CSVFile;
-#if NET50
+#if HAS_ASYNC
 using System.Threading.Tasks;
 #endif
 
@@ -252,7 +252,7 @@ namespace CSVTestSuite
             }
         }
         
-#if NET50
+#if HAS_ASYNC_IENUM
         [Test]
         public async Task TestAsyncReader()
         {

--- a/tests/SerializationTest.cs
+++ b/tests/SerializationTest.cs
@@ -240,7 +240,7 @@ namespace CSVTestSuite
             Assert.IsNull(list[3].NullableSingle);
         }
         
-#if HAS_ASYNC
+#if HAS_ASYNC_IENUM
         [Test]
         public async Task DeserializeLastColumnNullableSingleAsync()
         {

--- a/tests/net20/tests.net20.csproj
+++ b/tests/net20/tests.net20.csproj
@@ -14,7 +14,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>DEBUG;NET20;HAS_DATATABLE;HAS_SMTPCLIENT</DefineConstants>
+    <DefineConstants>DEBUG;NET2_0;HAS_DATATABLE;HAS_SMTPCLIENT</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
@@ -25,6 +25,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
+    <DefineConstants>NET2_0;HAS_DATATABLE;HAS_SMTPCLIENT</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/tests/net20/tests.net20.csproj
+++ b/tests/net20/tests.net20.csproj
@@ -14,7 +14,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>DEBUG;NET2_0;HAS_DATATABLE;HAS_SMTPCLIENT</DefineConstants>
+    <DefineConstants>DEBUG;NET2_0</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
@@ -25,7 +25,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
-    <DefineConstants>NET2_0;HAS_DATATABLE;HAS_SMTPCLIENT</DefineConstants>
+    <DefineConstants>NET2_0</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/tests/net40/tests.net40.csproj
+++ b/tests/net40/tests.net40.csproj
@@ -14,7 +14,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>DEBUG;NET40;HAS_DATATABLE;HAS_SMTPCLIENT</DefineConstants>
+    <DefineConstants>DEBUG;NET4_0;HAS_DATATABLE;HAS_SMTPCLIENT</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
@@ -25,6 +25,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
+    <DefineConstants>NET4_0;HAS_DATATABLE;HAS_SMTPCLIENT</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/tests/net40/tests.net40.csproj
+++ b/tests/net40/tests.net40.csproj
@@ -14,7 +14,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>DEBUG;NET4_0;HAS_DATATABLE;HAS_SMTPCLIENT</DefineConstants>
+    <DefineConstants>DEBUG;NET4_0</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
@@ -25,7 +25,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
-    <DefineConstants>NET4_0;HAS_DATATABLE;HAS_SMTPCLIENT</DefineConstants>
+    <DefineConstants>NET4_0</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/tests/net45/tests.net45.csproj
+++ b/tests/net45/tests.net45.csproj
@@ -15,7 +15,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>DEBUG;NET4_5;HAS_ASYNC;HAS_DATATABLE;</DefineConstants>
+    <DefineConstants>DEBUG;NET4_5;HAS_ASYNC;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
@@ -26,7 +26,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
-    <DefineConstants>NET4_5;HAS_ASYNC;HAS_DATATABLE;</DefineConstants>
+    <DefineConstants>NET4_5;HAS_ASYNC;</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/tests/net45/tests.net45.csproj
+++ b/tests/net45/tests.net45.csproj
@@ -15,7 +15,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>DEBUG;NET45;HAS_ASYNC;HAS_DATATABLE;</DefineConstants>
+    <DefineConstants>DEBUG;NET4_5;HAS_ASYNC;HAS_DATATABLE;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
@@ -26,6 +26,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
+    <DefineConstants>NET4_5;HAS_ASYNC;HAS_DATATABLE;</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/tests/net50/tests.net50.csproj
+++ b/tests/net50/tests.net50.csproj
@@ -8,11 +8,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DefineConstants>TRACE;NET50;HAS_DATATABLE;HAS_ASYNC;</DefineConstants>
+    <DefineConstants>HAS_DATATABLE;HAS_ASYNC;HAS_ASYNC_IENUM;</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <DefineConstants>TRACE;HAS_ASYNC;</DefineConstants>
+    <DefineConstants>HAS_DATATABLE;HAS_ASYNC;HAS_ASYNC_IENUM;</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/net50/tests.net50.csproj
+++ b/tests/net50/tests.net50.csproj
@@ -8,11 +8,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DefineConstants>HAS_DATATABLE;HAS_ASYNC;HAS_ASYNC_IENUM;</DefineConstants>
+    <DefineConstants>HAS_ASYNC;HAS_ASYNC_IENUM;</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <DefineConstants>HAS_DATATABLE;HAS_ASYNC;HAS_ASYNC_IENUM;</DefineConstants>
+    <DefineConstants>HAS_ASYNC;HAS_ASYNC_IENUM;</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/netstandard20/tests.netstandard20.csproj
+++ b/tests/netstandard20/tests.netstandard20.csproj
@@ -19,7 +19,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;NETSTANDARD2_0;HAS_DATATABLE;HAS_ASYNC;</DefineConstants>
+    <DefineConstants>DEBUG;NETSTANDARD2_0;HAS_ASYNC;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -27,7 +27,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>NETSTANDARD2_0;HAS_DATATABLE;HAS_ASYNC;</DefineConstants>
+    <DefineConstants>NETSTANDARD2_0;HAS_ASYNC;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/tests/netstandard20/tests.netstandard20.csproj
+++ b/tests/netstandard20/tests.netstandard20.csproj
@@ -19,7 +19,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;NETSTANDARD20;HAS_DATATABLE;</DefineConstants>
+    <DefineConstants>DEBUG;NETSTANDARD2_0;HAS_DATATABLE;HAS_ASYNC;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -27,7 +27,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE;NETSTANDARD20;HAS_DATATABLE;</DefineConstants>
+    <DefineConstants>NETSTANDARD2_0;HAS_DATATABLE;HAS_ASYNC;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>


### PR DESCRIPTION
I originally built the "version compatibility" code in this library back in 2016 when I released this as open source.  I didn't spend nearly enough time looking at the names.

This PR standardizes them:
* HAS_ASYNC - True for dot net 4.5 and later.
* HAS_ASYNC_IENUM - True for Net50 and later.

I removed HAS_DATATABLE and HAS_SMTPCLIENT.  These flag were true if the version of dot net included datatables or smtpclient objects.  They weren't present in the first few releases of NetCore, but they are now available everywhere, and NetStandard 1.0 is thankfully a thing of the past and we can let it die.