### PR TITLE
Add more precise tests for CR/LF characters

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -26,11 +26,11 @@ jobs:
             7.0.x
 
       - name: Build (Framework 2.0)
-        run: msbuild ./src/net20/src.net20.csproj
+        run: msbuild ./src/net20/src.net20.csproj /property:Configuration=Release
       - name: Build (Framework 4.0)
-        run: msbuild ./src/net40/src.net40.csproj
+        run: msbuild ./src/net40/src.net40.csproj /property:Configuration=Release
       - name: Build (Framework 4.5)
-        run: msbuild ./src/net45/src.net45.csproj
+        run: msbuild ./src/net45/src.net45.csproj /property:Configuration=Release
       - name: Build (DotNetCore 5.0)
         run: dotnet build -c Release ./src/net50/src.net50.csproj
       - name: Build (NetStandard 2.0)
@@ -43,7 +43,7 @@ jobs:
           nuget-version: "5.x"
 
       - name: Run Nuget pack
-        run: nuget pack Searchlight.nuspec
+        run: nuget pack CSVFile.nuspec
 
 #      - name: Push generated package to GitHub registry
 #        if: github.ref == 'refs/heads/main' && github.event_name == 'push'

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -1,0 +1,50 @@
+name: NuGet Publish
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Update NuGet package
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+
+      - name: Setup .NET Core @ Latest
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: |
+            5.0.x
+            6.0.x
+            7.0.x
+
+      - name: Build (Framework 2.0)
+        run: msbuild ./src/net20/src.net20.csproj
+      - name: Build (Framework 4.0)
+        run: msbuild ./src/net40/src.net40.csproj
+      - name: Build (Framework 4.5)
+        run: msbuild ./src/net45/src.net45.csproj
+      - name: Build (DotNetCore 5.0)
+        run: dotnet build -c Release ./src/net50/src.net50.csproj
+      - name: Build (NetStandard 2.0)
+        run: dotnet build -c Release ./src/netstandard20/src.netstandard20.csproj
+        
+      - name: Setup Nuget
+        uses: nuget/setup-nuget@v1
+        with:
+          nuget-api-key: ${{ secrets.NUGET_API_KEY }}
+          nuget-version: "5.x"
+
+      - name: Run Nuget pack
+        run: nuget pack Searchlight.nuspec
+
+#      - name: Push generated package to GitHub registry
+#        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+#        run: nuget push *.nupkg -Source 'https://api.nuget.org/v3/index.json' -ApiKey ${{secrets.NUGET_API_KEY}}

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -3,8 +3,6 @@ name: NuGet Publish
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -45,6 +43,6 @@ jobs:
       - name: Run Nuget pack
         run: nuget pack CSVFile.nuspec
 
-#      - name: Push generated package to GitHub registry
-#        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-#        run: nuget push *.nupkg -Source 'https://api.nuget.org/v3/index.json' -ApiKey ${{secrets.NUGET_API_KEY}}
+      - name: Push generated package to GitHub registry
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        run: nuget push *.nupkg -Source 'https://api.nuget.org/v3/index.json' -ApiKey ${{secrets.NUGET_API_KEY}}

--- a/CSVFile.nuspec
+++ b/CSVFile.nuspec
@@ -33,10 +33,10 @@
 		<file src=".\LICENSE" target="docs/LICENSE"/>
 		<file src=".\README.md" target="docs/README.md"/>
 		<file src=".\icons8-spreadsheet-96.png" target="docs/icons8-spreadsheet-96.png"/>
-		<file src="src\net20\bin\release\net20\*" target="lib\net20" />
-		<file src="src\net40\bin\release\net40\*" target="lib\net40" />
-		<file src="src\net45\bin\release\net45\*" target="lib\net45" />
-		<file src="src\netstandard20\bin\release\netstandard2.0\*" target="lib\netstandard20" />
-		<file src="src\net50\bin\release\net5.0\*" target="lib\net5.0" />
+		<file src="src\net20\bin\Release\net20\*" target="lib\net20" />
+		<file src="src\net40\bin\Release\net40\*" target="lib\net40" />
+		<file src="src\net45\bin\Release\net45\*" target="lib\net45" />
+		<file src="src\netstandard20\bin\Release\netstandard2.0\*" target="lib\netstandard20" />
+		<file src="src\net50\bin\Release\net5.0\*" target="lib\net5.0" />
 	</files>
 </package>

--- a/CSVFile.nuspec
+++ b/CSVFile.nuspec
@@ -33,9 +33,9 @@
 		<file src=".\LICENSE" target="docs/LICENSE"/>
 		<file src=".\README.md" target="docs/README.md"/>
 		<file src=".\icons8-spreadsheet-96.png" target="docs/icons8-spreadsheet-96.png"/>
-		<file src="src\net20\bin\Release\net20\*" target="lib\net20" />
-		<file src="src\net40\bin\Release\net40\*" target="lib\net40" />
-		<file src="src\net45\bin\Release\net45\*" target="lib\net45" />
+		<file src="src\net20\bin\Release\*" target="lib\net20" />
+		<file src="src\net40\bin\Release\*" target="lib\net40" />
+		<file src="src\net45\bin\Release\*" target="lib\net45" />
 		<file src="src\netstandard20\bin\Release\netstandard2.0\*" target="lib\netstandard20" />
 		<file src="src\net50\bin\Release\net5.0\*" target="lib\net5.0" />
 	</files>

--- a/CSVFile.nuspec
+++ b/CSVFile.nuspec
@@ -2,20 +2,20 @@
 <package >
 	<metadata>
 		<id>CSVFile</id>
-		<version>3.1.1</version>
+		<version>3.1.2</version>
 		<title>CSVFile</title>
 		<authors>Ted Spence</authors>
 		<owners>Ted Spence</owners>
 		<license type="file">docs/LICENSE</license>
 		<projectUrl>https://github.com/tspence/csharp-csv-reader</projectUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
-		<summary>Tiny and fast CSV and TSV parsing library (40KB) with zero dependencies.  Compatible with most dot net versions.</summary>
-		<description>Tiny and fast CSV and TSV parsing library (40KB) with zero dependencies.  Compatible with most dot net versions.</description>
+		<summary>Tiny and fast CSV and TSV parsing library (40KB) with zero dependencies.  Compatible with DotNetFramework (2.0 onwards) and DotNetCore.</summary>
+		<description>Tiny and fast CSV and TSV parsing library (40KB) with zero dependencies.  Compatible with DotNetFramework (2.0 onwards) and DotNetCore.</description>
 		<icon>docs/icons8-spreadsheet-96.png</icon>
 		<releaseNotes>
-			March 7, 2023
+			July 18, 2023
 			
-			* Fix issue when reading a stream with a text qualified field that ends with a newline
+			* Fix issue with inconsistent handling of embedded newlines in the streaming version of the reader
 		</releaseNotes>
 		<readme>docs/README.md</readme>
 		<copyright>Copyright 2006 - 2023</copyright>

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 [![NuGet](https://img.shields.io/nuget/v/CSVFile.svg?style=plastic)](https://www.nuget.org/packages/CSVFile/)
-![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/tspence/csharp-csv-reader/dotnet.yml?branch=main)
-[![SonarCloud Coverage](https://sonarcloud.io/api/project_badges/measure?project=tspence_csharp-csv-reader&metric=coverage)](https://sonarcloud.io/component_measures?id=tspence_csharp-csv-reader&metric=coverage&view=list)
-[![SonarCloud Bugs](https://sonarcloud.io/api/project_badges/measure?project=tspence_csharp-csv-reader&metric=bugs)](https://sonarcloud.io/project/issues?resolved=false&types=BUG&id=tspence_csharp-csv-reader)
-[![SonarCloud Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=tspence_csharp-csv-reader&metric=vulnerabilities)](https://sonarcloud.io/project/issues?resolved=false&types=VULNERABILITY&id=tspence_csharp-csv-reader)
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/tspence/csharp-csv-reader/dotnet.yml?branch=main)](https://github.com/tspence/csharp-csv-reader/actions/workflows/dotnet.yml)
+[![SonarCloud Coverage](https://sonarcloud.io/api/project_badges/measure?project=tspence_csharp-csv-reader&metric=coverage)](https://sonarcloud.io/summary/overall?id=tspence_csharp-csv-reader)
+[![SonarCloud Bugs](https://sonarcloud.io/api/project_badges/measure?project=tspence_csharp-csv-reader&metric=bugs)](https://sonarcloud.io/summary/overall?id=tspence_csharp-csv-reader)
+[![SonarCloud Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=tspence_csharp-csv-reader&metric=vulnerabilities)](https://sonarcloud.io/summary/overall?id=tspence_csharp-csv-reader)
 
 # CSVFile
 This library is a series of unit tested, thoroughly commented CSV parsing functions which I have developed off and on since 2006. Extremely small and easy to implement; includes unit tests for the majority of odd CSV edge cases. Library supports different delimiters, qualifiers, and embedded newlines. Can read and write from data tables.

--- a/src/CSV.cs
+++ b/src/CSV.cs
@@ -56,24 +56,22 @@ namespace CSVFile
         /// <returns>An enumerable object that can be examined to retrieve rows from the stream.</returns>
         public static IEnumerable<string[]> ParseStream(StreamReader inStream, CSVSettings settings = null)
         {
+            int bufferSize = settings?.BufferSize ?? CSVSettings.DEFAULT_BUFFER_SIZE;
+            var buffer = new char[bufferSize];
             var machine = new CSVStateMachine(settings);
             while (machine.State == CSVState.CanKeepGoing)
             {
                 var line = string.Empty;
                 if (!inStream.EndOfStream)
                 {
-                    line = inStream.ReadLine();
+                    var readChars = inStream.ReadBlock(buffer, 0, bufferSize);
+                    line = new string(buffer, 0, readChars);
                 }
                 var row = machine.ParseLine(line, inStream.EndOfStream);
                 if (row != null)
                 {
                     yield return row;
                 } 
-                else
-                {
-                    // We didn't get a row, so add environment newline
-                    machine.ParseChunk(Environment.NewLine, false);
-                }
             }
         }
 
@@ -86,13 +84,16 @@ namespace CSVFile
         /// <returns>An enumerable object that can be examined to retrieve rows from the stream.</returns>
         public static async IAsyncEnumerable<string[]> ParseStreamAsync(StreamReader inStream, CSVSettings settings = null)
         {
+            int bufferSize = settings?.BufferSize ?? CSVSettings.DEFAULT_BUFFER_SIZE;
+            var buffer = new char[bufferSize];
             var machine = new CSVStateMachine(settings);
             while (machine.State == CSVState.CanKeepGoing)
             {
                 var line = string.Empty;
                 if (!inStream.EndOfStream)
                 {
-                    line = await inStream.ReadLineAsync();
+                    var readChars = await inStream.ReadBlockAsync(buffer, 0, bufferSize);
+                    line = new string(buffer, 0, readChars);
                 }
                 var row = machine.ParseLine(line, inStream.EndOfStream);
                 if (row != null)

--- a/src/CSV.cs
+++ b/src/CSV.cs
@@ -62,7 +62,7 @@ namespace CSVFile
             while (machine.State == CSVState.CanKeepGoing)
             {
                 var line = string.Empty;
-                if (!inStream.EndOfStream)
+                if (machine.NeedsMoreText() && !inStream.EndOfStream)
                 {
                     var readChars = inStream.ReadBlock(buffer, 0, bufferSize);
                     line = new string(buffer, 0, readChars);
@@ -90,7 +90,7 @@ namespace CSVFile
             while (machine.State == CSVState.CanKeepGoing)
             {
                 var line = string.Empty;
-                if (!inStream.EndOfStream)
+                if (machine.NeedsMoreText() && !inStream.EndOfStream)
                 {
                     var readChars = await inStream.ReadBlockAsync(buffer, 0, bufferSize);
                     line = new string(buffer, 0, readChars);

--- a/src/CSV.cs
+++ b/src/CSV.cs
@@ -67,7 +67,7 @@ namespace CSVFile
                     var readChars = inStream.ReadBlock(buffer, 0, bufferSize);
                     line = new string(buffer, 0, readChars);
                 }
-                var row = machine.ParseLine(line, inStream.EndOfStream);
+                var row = machine.ParseChunk(line, inStream.EndOfStream);
                 if (row != null)
                 {
                     yield return row;
@@ -95,7 +95,7 @@ namespace CSVFile
                     var readChars = await inStream.ReadBlockAsync(buffer, 0, bufferSize);
                     line = new string(buffer, 0, readChars);
                 }
-                var row = machine.ParseLine(line, inStream.EndOfStream);
+                var row = machine.ParseChunk(line, inStream.EndOfStream);
                 if (row != null)
                 {
                     yield return row;

--- a/src/CSV.cs
+++ b/src/CSV.cs
@@ -68,6 +68,11 @@ namespace CSVFile
                 if (row != null)
                 {
                     yield return row;
+                } 
+                else
+                {
+                    // We didn't get a row, so add environment newline
+                    machine.ParseChunk(Environment.NewLine, false);
                 }
             }
         }

--- a/src/CSVSettings.cs
+++ b/src/CSVSettings.cs
@@ -118,6 +118,12 @@ namespace CSVFile
         public bool IgnoreEmptyLineForDeserialization { get; set; }
 
         /// <summary>
+        /// When reading data from a stream, this is the block size to read at once.
+        /// </summary>
+        public int BufferSize { get; set; } = DEFAULT_BUFFER_SIZE;
+        internal static readonly int DEFAULT_BUFFER_SIZE = 65536;
+
+        /// <summary>
         /// The encoding for converting streams of bytes to strings
         /// </summary>
         public Encoding Encoding { get; set; } = Encoding.UTF8;

--- a/src/CSVStateMachine.cs
+++ b/src/CSVStateMachine.cs
@@ -60,6 +60,15 @@ namespace CSVFile
         public CSVState State { get; private set; }
 
         /// <summary>
+        /// Returns true if we need more text
+        /// </summary>
+        /// <returns></returns>
+        public bool NeedsMoreText()
+        {
+            return String.IsNullOrEmpty(_line) || _position == _line.Length;
+        }
+
+        /// <summary>
         /// Constructs a new state machine to begin processing CSV text
         /// </summary>
         public CSVStateMachine(CSVSettings settings)
@@ -104,7 +113,7 @@ namespace CSVFile
         public string[] ParseChunk(string chunk, bool reachedEnd)
         {
             // Detect end of stream
-            if (reachedEnd && string.IsNullOrEmpty(chunk) && _position == -1)
+            if (reachedEnd && string.IsNullOrEmpty(chunk) && _position == -1 && string.IsNullOrEmpty(_line))
             {
                 State = CSVState.Done;
                 return null;

--- a/src/CSVStateMachine.cs
+++ b/src/CSVStateMachine.cs
@@ -65,7 +65,7 @@ namespace CSVFile
         /// <returns></returns>
         public bool NeedsMoreText()
         {
-            return String.IsNullOrEmpty(_line) || _position == _line.Length;
+            return String.IsNullOrEmpty(_line) || _position >= _line.Length;
         }
 
         /// <summary>
@@ -88,20 +88,6 @@ namespace CSVFile
         }
 
         /// <summary>
-        /// Parse a single line when read from a stream.
-        ///
-        /// Call this function when you are using the "ReadLine" or "ReadLineAsync" functions so that
-        /// each line will obey the CSV Settings rules for line separators.
-        /// </summary>
-        /// <param name="line"></param>
-        /// <param name="reachedEnd"></param>
-        /// <returns></returns>
-        public string[] ParseLine(string line, bool reachedEnd)
-        {
-            return ParseChunk(line, reachedEnd);
-        }
-
-        /// <summary>
         /// Parse a new chunk of text retrieved via some other means than a stream.
         ///
         /// Call this function when you are retrieving your own text and when each chunk may or may not
@@ -117,6 +103,12 @@ namespace CSVFile
             {
                 State = CSVState.Done;
                 return null;
+            }
+
+            // If we're at the end of the line, remember to backtrack one because we increment immediately
+            if (_position == _line.Length)
+            {
+                _position -= 1;
             }
 
             // Add this chunk to the current processing logic

--- a/src/CSVStateMachine.cs
+++ b/src/CSVStateMachine.cs
@@ -195,18 +195,21 @@ namespace CSVFile
                     _position--;
                 }
                 // Are we at a line separator? Let's do a quick test first
-                else if (c == _settings.LineSeparator[0] && _position + _settings.LineSeparator.Length <= _line.Length)
+                else if (c == _settings.LineSeparator[0])
                 {
-                    if (string.Equals(_line.Substring(_position, _settings.LineSeparator.Length),
-                            _settings.LineSeparator))
+                    if (_position + _settings.LineSeparator.Length <= _line.Length)
                     {
-                        _line = _line.Substring(_position + _settings.LineSeparator.Length);
-                        _position = -1;
-                        _list.Add(_work.ToString());
-                        var row = _list.ToArray();
-                        _list.Clear();
-                        _work.Length = 0;
-                        return row;
+                        if (string.Equals(_line.Substring(_position, _settings.LineSeparator.Length),
+                                _settings.LineSeparator))
+                        {
+                            _line = _line.Substring(_position + _settings.LineSeparator.Length);
+                            _position = -1;
+                            _list.Add(_work.ToString());
+                            var row = _list.ToArray();
+                            _list.Clear();
+                            _work.Length = 0;
+                            return row;
+                        }
                     }
                 }
                 // Does this start a new field?

--- a/src/CSVStateMachine.cs
+++ b/src/CSVStateMachine.cs
@@ -89,10 +89,6 @@ namespace CSVFile
         /// <returns></returns>
         public string[] ParseLine(string line, bool reachedEnd)
         {
-            if (!string.IsNullOrEmpty(line))
-            {
-                line += _settings.LineSeparator;
-            }
             return ParseChunk(line, reachedEnd);
         }
 

--- a/src/CSVStateMachine.cs
+++ b/src/CSVStateMachine.cs
@@ -198,19 +198,33 @@ namespace CSVFile
                 // Are we at a line separator? Let's do a quick test first
                 else if (c == _settings.LineSeparator[0])
                 {
-                    if (_position + _settings.LineSeparator.Length <= _line.Length)
+                    // If we don't have enough characters left to test the line separator properly, ask for more
+                    var notEnoughChars = _position + _settings.LineSeparator.Length > _line.Length;
+                    if (notEnoughChars && !reachedEnd)
                     {
-                        if (string.Equals(_line.Substring(_position, _settings.LineSeparator.Length),
-                                _settings.LineSeparator))
-                        {
-                            _line = _line.Substring(_position + _settings.LineSeparator.Length);
-                            _position = -1;
-                            _list.Add(_work.ToString());
-                            var row = _list.ToArray();
-                            _list.Clear();
-                            _work.Length = 0;
-                            return row;
-                        }
+                        return null;
+                    }
+
+                    // If we have reached the end, but this isn't a complete line separator, it's just text
+                    if (notEnoughChars && reachedEnd)
+                    {
+                        _work.Append(c);
+                    }
+                    // OK, we have enough characters, see if this is a line separator
+                    else if (string.Equals(_line.Substring(_position, _settings.LineSeparator.Length), _settings.LineSeparator))
+                    {
+                        _line = _line.Substring(_position + _settings.LineSeparator.Length);
+                        _position = -1;
+                        _list.Add(_work.ToString());
+                        var row = _list.ToArray();
+                        _list.Clear();
+                        _work.Length = 0;
+                        return row;
+                    }
+                    // It's not a line separator, it's just a normal character
+                    else
+                    {
+                        _work.Append(c);
                     }
                 }
                 // Does this start a new field?

--- a/tests/AsyncReaderTest.cs
+++ b/tests/AsyncReaderTest.cs
@@ -27,7 +27,8 @@ namespace CSVTestSuite
             // Skip header row
             var settings = new CSVSettings()
             {
-                HeaderRowIncluded = false
+                HeaderRowIncluded = false,
+                LineSeparator = "\n",
             };
 
             // Convert into stream
@@ -88,7 +89,8 @@ namespace CSVTestSuite
             // Skip header row
             var settings = new CSVSettings()
             {
-                HeaderRowIncluded = false
+                HeaderRowIncluded = false,
+                LineSeparator = "\n",
             };
 
             // Convert into stream
@@ -156,7 +158,7 @@ namespace CSVTestSuite
                          "Dr. Kelso\tChief of Medicine\tx100";
 
             // Convert into stream
-            var settings = new CSVSettings() { HeaderRowIncluded = true, FieldDelimiter = '\t' };
+            var settings = new CSVSettings() { HeaderRowIncluded = true, FieldDelimiter = '\t', LineSeparator = "\n" };
             using (var cr = CSVReader.FromString(source, settings))
             {
                 Assert.AreEqual("Name", cr.Headers[0]);

--- a/tests/BasicParseTests.cs
+++ b/tests/BasicParseTests.cs
@@ -236,5 +236,24 @@ namespace CSVTestSuite
             Assert.AreEqual("Normal", line3[9]);
             Assert.AreEqual("", line3[10]);
         }
+
+        [Test]
+        public void TestMultipleNewlines()
+        {
+            // Specific issue reported by domdere
+            var line1 = CSV.ParseLine("\"test\",\"blah\r\n\r\n\r\nfoo\",\"Normal\"");
+            Assert.AreEqual("test", line1[0]);
+            Assert.AreEqual("blah\r\n\r\n\r\nfoo", line1[1]);
+            Assert.AreEqual("Normal", line1[2]);
+
+            // Test a few potential use cases here
+            var line2 = CSV.ParseLine("\"test\",\"\n\n\",\"\r\n\r\n\r\n\",\"Normal\",\"\",\"\r\r\r\r\r\"");
+            Assert.AreEqual("test", line2[0]);
+            Assert.AreEqual("\n\n", line2[1]);
+            Assert.AreEqual("\r\n\r\n\r\n", line2[2]);
+            Assert.AreEqual("Normal", line2[3]);
+            Assert.AreEqual("", line2[4]);
+            Assert.AreEqual("\r\r\r\r\r", line2[5]);
+        }
     }
 }

--- a/tests/ChopTest.cs
+++ b/tests/ChopTest.cs
@@ -97,7 +97,6 @@ namespace CSVTestSuite
                     Assert.AreEqual(list[i].email, results[i].email);
                 }
             }
-            // Clean up
             finally
             {
                 if (Directory.Exists(dirname))

--- a/tests/DataTableReaderTest.cs
+++ b/tests/DataTableReaderTest.cs
@@ -33,7 +33,11 @@ namespace CSVTestSuite
         [Test]
         public void TestBasicDataTable()
         {
-            var dt = CSVDataTable.FromString(source);
+            var settings = new CSVSettings()
+            {
+                LineSeparator = "\n",
+            };
+            var dt = CSVDataTable.FromString(source, settings);
             Assert.AreEqual(3, dt.Columns.Count);
             Assert.AreEqual(4, dt.Rows.Count);
             Assert.AreEqual("JD", dt.Rows[0].ItemArray[0]);
@@ -53,12 +57,16 @@ namespace CSVTestSuite
         [Test]
         public void TestDataTableWithEmbeddedNewlines()
         {
-            var dt = CSVDataTable.FromString(source_embedded_newlines);
+            var settings = new CSVSettings()
+            {
+                LineSeparator = "\n",
+            };
+            var dt = CSVDataTable.FromString(source_embedded_newlines, settings);
             Assert.AreEqual(3, dt.Columns.Count);
             Assert.AreEqual(4, dt.Rows.Count);
             Assert.AreEqual("JD", dt.Rows[0].ItemArray[0]);
             Assert.AreEqual("Janitor", dt.Rows[1].ItemArray[0]);
-            Assert.AreEqual("Dr. Reed, " + Environment.NewLine + "Eliot", dt.Rows[2].ItemArray[0]);
+            Assert.AreEqual("Dr. Reed, \nEliot", dt.Rows[2].ItemArray[0]);
             Assert.AreEqual("Dr. Kelso", dt.Rows[3].ItemArray[0]);
             Assert.AreEqual("Doctor", dt.Rows[0].ItemArray[1]);
             Assert.AreEqual("Janitor", dt.Rows[1].ItemArray[1]);

--- a/tests/ReaderTest.cs
+++ b/tests/ReaderTest.cs
@@ -283,13 +283,13 @@ namespace CSVTestSuite
             }
         }
 
-
         [Test]
         public void TestMultipleNewlines()
         {
             var settings = new CSVSettings()
             {
-                HeaderRowIncluded = false
+                HeaderRowIncluded = false,
+                LineSeparator = "\r\n",
             };
 
             // This use case was reported by domdere as https://github.com/tspence/csharp-csv-reader/issues/59
@@ -316,6 +316,22 @@ namespace CSVTestSuite
                     Assert.AreEqual("Normal", line[3]);
                     Assert.AreEqual("", line[4]);
                     Assert.AreEqual("\r\r\r\r\r", line[5]);
+                }
+            }
+
+            // Test a false single CR within the text
+            var source3 = "\"test\",\"\n\n\",\"\r\n\r\n\r\n\",\"Normal\",\"\",\"\r\r\r\r\r\",\r\r\r\n";
+            using (var cr = CSVReader.FromString(source3, settings))
+            {
+                foreach (var line in cr.Lines())
+                {
+                    Assert.AreEqual("test", line[0]);
+                    Assert.AreEqual("\n\n", line[1]);
+                    Assert.AreEqual("\r\n\r\n\r\n", line[2]);
+                    Assert.AreEqual("Normal", line[3]);
+                    Assert.AreEqual("", line[4]);
+                    Assert.AreEqual("\r\r\r\r\r", line[5]);
+                    Assert.AreEqual("\r\r", line[6]);
                 }
             }
         }

--- a/tests/ReaderTest.cs
+++ b/tests/ReaderTest.cs
@@ -281,6 +281,43 @@ namespace CSVTestSuite
             }
         }
 
+
+        [Test]
+        public void TestMultipleNewlines()
+        {
+            var settings = new CSVSettings()
+            {
+                HeaderRowIncluded = false
+            };
+
+            // This use case was reported by domdere as https://github.com/tspence/csharp-csv-reader/issues/59
+            var source = "\"test\",\"blah\r\n\r\n\r\nfoo\",\"Normal\"";
+            using (var cr = CSVReader.FromString(source, settings))
+            {
+                foreach (var line in cr.Lines())
+                {
+                    Assert.AreEqual("test", line[0]);
+                    Assert.AreEqual("blah\r\n\r\n\r\nfoo", line[1]);
+                    Assert.AreEqual("Normal", line[2]);
+                }
+            }
+
+            // Test a few potential use cases here
+            var source2 = "\"test\",\"\n\n\",\"\r\n\r\n\r\n\",\"Normal\",\"\",\"\r\r\r\r\r\"";
+            using (var cr = CSVReader.FromString(source2, settings))
+            {
+                foreach (var line in cr.Lines())
+                {
+                    Assert.AreEqual("test", line[0]);
+                    Assert.AreEqual("\n\n", line[1]);
+                    Assert.AreEqual("\r\n\r\n\r\n", line[2]);
+                    Assert.AreEqual("Normal", line[3]);
+                    Assert.AreEqual("", line[4]);
+                    Assert.AreEqual("\r\r\r\r\r", line[5]);
+                }
+            }
+        }
+
 #if HAS_ASYNC_IENUM
         [Test]
         public async Task TestAsyncReader()

--- a/tests/ReaderTest.cs
+++ b/tests/ReaderTest.cs
@@ -29,7 +29,8 @@ namespace CSVTestSuite
             // Skip header row
             var settings = new CSVSettings()
             {
-                HeaderRowIncluded = false
+                HeaderRowIncluded = false,
+                LineSeparator = "\n",
             };
 
             // Convert into stream
@@ -88,7 +89,8 @@ namespace CSVTestSuite
             // Skip header row
             var settings = new CSVSettings()
             {
-                HeaderRowIncluded = false
+                HeaderRowIncluded = false,
+                LineSeparator = "\n",
             };
 
             // Convert into stream
@@ -156,7 +158,7 @@ namespace CSVTestSuite
                          "Dr. Kelso\tChief of Medicine\tx100";
 
             // Convert into stream
-            var settings = new CSVSettings() { HeaderRowIncluded = true, FieldDelimiter = '\t' };
+            var settings = new CSVSettings() { HeaderRowIncluded = true, FieldDelimiter = '\t', LineSeparator = "\n", };
             using (var cr = CSVReader.FromString(source, settings))
             {
                 Assert.AreEqual("Name", cr.Headers[0]);
@@ -210,7 +212,7 @@ namespace CSVTestSuite
                          "Dr. Kelso|Chief of Medicine|x100";
 
             // Convert into stream
-            var settings = new CSVSettings() { HeaderRowIncluded = true, FieldDelimiter = '\t', AllowSepLine = true };
+            var settings = new CSVSettings() { HeaderRowIncluded = true, FieldDelimiter = '\t', AllowSepLine = true, LineSeparator = "\n", };
             using (var cr = CSVReader.FromString(source, settings))
             {
                 // The field delimiter should have been changed, but the original object should remain the same
@@ -333,7 +335,7 @@ namespace CSVTestSuite
                          "Dr. Kelso|Chief of Medicine|x100";
 
             // Convert into stream
-            var settings = new CSVSettings() { HeaderRowIncluded = true, FieldDelimiter = '\t', AllowSepLine = true };
+            var settings = new CSVSettings() { HeaderRowIncluded = true, FieldDelimiter = '\t', LineSeparator = "\n", AllowSepLine = true };
             using (var cr = CSVReader.FromString(source, settings))
             {
                 // The field delimiter should have been changed, but the original object should remain the same

--- a/tests/SerializationTest.cs
+++ b/tests/SerializationTest.cs
@@ -223,6 +223,7 @@ namespace CSVTestSuite
             settings.AllowNull = true;
             settings.NullToken = string.Empty;
             settings.IgnoreEmptyLineForDeserialization = true;
+            settings.LineSeparator = "\n";
 
             // Deserialize back from a CSV string - should not throw any errors!
             var list = CSV.Deserialize<TestClassLastColumnNullableSingle>(csv, settings).ToList();
@@ -261,6 +262,7 @@ namespace CSVTestSuite
             settings.AllowNull = true;
             settings.NullToken = string.Empty;
             settings.IgnoreEmptyLineForDeserialization = true;
+            settings.LineSeparator = "\n";
 
             // Try deserializing using the async version
             var list = await CSV.DeserializeAsync<TestClassLastColumnNullableSingle>(csv, settings).ToListAsync();
@@ -306,7 +308,8 @@ namespace CSVTestSuite
             {
                 AllowNull = true,
                 NullToken = string.Empty,
-                IgnoreEmptyLineForDeserialization = true
+                IgnoreEmptyLineForDeserialization = true,
+                LineSeparator = "\n",
             };
 
             // Deserialize back from a CSV string - should throw an error because "ReadOnlySingle" is read only
@@ -376,7 +379,8 @@ namespace CSVTestSuite
                 AllowNull = true,
                 NullToken = string.Empty,
                 IgnoreEmptyLineForDeserialization = true,
-                ExcludedColumns = new []{ "TestString" }
+                ExcludedColumns = new []{ "TestString" },
+                LineSeparator = "\n",
             };
 
             // Try deserializing - we should see nulls in the TestString column

--- a/tests/SerializationTest.cs
+++ b/tests/SerializationTest.cs
@@ -141,7 +141,8 @@ namespace CSVTestSuite
                 "NULL,7,Fourth";
 
             // Deserialize back from a CSV string - should not throw any errors!
-            var newList = CSV.Deserialize<TestClassTwo>(csv, CSVSettings.CSV_PERMIT_NULL).ToList();
+            var permitNull = new CSVSettings() { AllowNull = true, LineSeparator = "\n", NullToken = "NULL" };
+            var newList = CSV.Deserialize<TestClassTwo>(csv, permitNull).ToList();
 
             // Compare original objects to new ones
             for (var i = 0; i < list.Count; i++)
@@ -164,6 +165,7 @@ namespace CSVTestSuite
             {
                 AllowNull = true,
                 NullToken = string.Empty,
+                LineSeparator = "\n",
             };
 
             // Deserialize back from a CSV string - should not throw any errors!
@@ -186,6 +188,7 @@ namespace CSVTestSuite
             {
                 AllowNull = true,
                 NullToken = "SPECIAL_NULL",
+                LineSeparator = "\n",
             };
 
             // Deserialize back from a CSV string - should not throw any errors!


### PR DESCRIPTION
As reported in #59 the streaming version of the CSV reader has problems with newline characters.  This is because decades ago I chose to use `StreamReader.ReadLine()` ... which was not the right choice.  A better approach is to use `ReadBlock()` which then doesn't suffer from newline standardization issues between CR and CRLF, as well as ensuring that empty lines and empty blocks are tracked more precisely.

In order to make this work, I updated a lot of old tests to explicitly look for either CR or CRLF.  I think I need to add more tests for CRLF pairs and ensure that it doesn't get lost on seeing the initial CR.