### PR TITLE
Add support for nested serialization of arrays

### DIFF
--- a/CSVFile.nuspec
+++ b/CSVFile.nuspec
@@ -2,7 +2,7 @@
 <package >
 	<metadata>
 		<id>CSVFile</id>
-		<version>3.1.2</version>
+		<version>3.1.3</version>
 		<title>CSVFile</title>
 		<authors>Ted Spence</authors>
 		<owners>Ted Spence</owners>
@@ -15,10 +15,10 @@
 		<releaseNotes>
 			July 18, 2023
 			
-			* Fix issue with inconsistent handling of embedded newlines in the streaming version of the reader
+			* Add serialization options for arrays
 		</releaseNotes>
 		<readme>docs/README.md</readme>
-		<copyright>Copyright 2006 - 2023</copyright>
+		<copyright>Copyright 2006 - 2024</copyright>
     	<tags>fast csv parser serialization deserialization streaming async</tags>
 		<repository type="git" url="https://github.com/tspence/csharp-csv-reader" />
 		<dependencies>

--- a/src/CSV.cs
+++ b/src/CSV.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
 #if HAS_ASYNC
 using System.Threading.Tasks;
@@ -360,11 +359,24 @@ namespace CSVFile
                 // Special cases for other types of serialization
                 string s;
                 var itemType = item.GetType();
+                var interfaces = itemType.GetInterfaces();
+                bool isEnumerable = false;
+                if (itemType != typeof(string))
+                {
+                    foreach (var itemInterface in interfaces)
+                    {
+                        if (itemInterface == typeof(IEnumerable))
+                        {
+                            isEnumerable = true;
+                        }
+                    }
+                }
+
                 if (item is DateTime)
                 {
                     s = ((DateTime)item).ToString(settings.DateTimeFormat);
                 }
-                else if (itemType != typeof(string) && itemType.GetInterfaces().Contains(typeof(IEnumerable)))
+                else if (isEnumerable)
                 {
                     IEnumerable enumerable = item as IEnumerable;
                     s = string.Empty;

--- a/src/CSVSettings.cs
+++ b/src/CSVSettings.cs
@@ -10,6 +10,32 @@ using System.Text;
 namespace CSVFile
 {
     /// <summary>
+    /// Defines the behavior of CSV serialization when a nested array is encountered
+    /// </summary>
+    public enum ArrayOptions
+    {
+        /// <summary>
+        /// Use built-in string conversion, which renders arrays as `MyObject[]` 
+        /// </summary>
+        ToString,
+        
+        /// <summary>
+        /// Convert any array columns that are array types into nulls (either blanks or null tokens)
+        /// </summary>
+        TreatAsNull,
+        
+        /// <summary>
+        /// Render the number of items in the array
+        /// </summary>
+        CountItems,
+        
+        /// <summary>
+        /// Serialize child objects recursively using the same settings
+        /// </summary>
+        RecursiveSerialization,
+    }
+    
+    /// <summary>
     /// Settings to configure how a CSV file is parsed
     /// </summary>
     public class CSVSettings
@@ -134,10 +160,15 @@ namespace CSVFile
         public string DateTimeFormat { get; set; } = "o";
 
         /// <summary>
+        /// The behavior to use when serializing a column of an array type
+        /// </summary>
+        public ArrayOptions NestedArrayBehavior = ArrayOptions.TreatAsNull;
+
+        /// <summary>
         /// Standard comma-separated value (CSV) file settings
         /// </summary>
         public static readonly CSVSettings CSV = new CSVSettings();
-
+        
         /// <summary>
         /// Standard comma-separated value (CSV) file settings that permit rendering of NULL values
         /// </summary>

--- a/tests/SerializationTest.cs
+++ b/tests/SerializationTest.cs
@@ -178,6 +178,12 @@ namespace CSVTestSuite
             var ignoreArraysCsv = CSV.Serialize(list, options);
             Assert.AreEqual($"Name,StringArray,IntList,BoolEnumerable,GuidList,NullableList{Environment.NewLine}"
                 + $"Test,NULL,NULL,NULL,NULL,NULL{Environment.NewLine}", ignoreArraysCsv);
+
+            // And now for the magic: Recursive serialization!
+            options.NestedArrayBehavior = ArrayOptions.RecursiveSerialization;
+            var recursiveCsv = CSV.Serialize(list, options);
+            Assert.AreEqual($"Name,StringArray,IntList,BoolEnumerable,GuidList,NullableList{Environment.NewLine}"
+                            + $"Test,\"a,b,c\",\"1,2,3\",\"True,False,True,False\",,NULL{Environment.NewLine}", recursiveCsv);
         }
         
         [Test]


### PR DESCRIPTION
When doing serialization of complex objects, sometimes you have array members.  Let's create options for custom column handling.