### PR TITLE
Fix NullReferenceException for empty headers

### DIFF
--- a/src/CSVReader.cs
+++ b/src/CSVReader.cs
@@ -334,7 +334,7 @@ namespace CSVFile
             if (_settings.HeaderRowIncluded)
             {
                 var line = source.ReadLine();
-                if (_settings.AllowSepLine)
+                if (line != null && _settings.AllowSepLine)
                 {
                     var newDelimiter = CSV.ParseSepLine(line);
                     if (newDelimiter != null)
@@ -345,7 +345,7 @@ namespace CSVFile
                     }
                 }
 
-                Headers = CSV.ParseLine(line, _settings);
+                Headers = CSV.ParseLine(line, _settings) ?? Array.Empty<string>();
             }
             else
             {
@@ -371,7 +371,7 @@ namespace CSVFile
             if (_settings.HeaderRowIncluded)
             {
                 var line = _stream.ReadLine();
-                if (_settings.AllowSepLine)
+                if (line != null && _settings.AllowSepLine)
                 {
                     var newDelimiter = CSV.ParseSepLine(line);
                     if (newDelimiter != null)
@@ -382,7 +382,7 @@ namespace CSVFile
                     }
                 }
 
-                Headers = CSV.ParseLine(line, _settings);
+                Headers = CSV.ParseLine(line, _settings) ?? Array.Empty<string>();
             }
             else
             {

--- a/tests/BasicParseTests.cs
+++ b/tests/BasicParseTests.cs
@@ -185,6 +185,8 @@ namespace CSVTestSuite
             Assert.AreEqual(',', CSV.ParseSepLine("sep=,"));
             Assert.AreEqual(',', CSV.ParseSepLine("sep = ,"));
             Assert.AreEqual(null, CSV.ParseSepLine("sep="));
+            Assert.AreEqual(null, CSV.ParseSepLine("sep=   "));
+            Assert.AreEqual(null, CSV.ParseSepLine("sep    =   "));
             Assert.Throws<Exception>(() =>
             {
                 CSV.ParseSepLine("sep= this is a test since separators can't be more than a single character");

--- a/tests/ReaderTest.cs
+++ b/tests/ReaderTest.cs
@@ -375,6 +375,145 @@ namespace CSVTestSuite
             Assert.AreEqual(desiredLines, outputLines);
         }
 
+        [Test]
+        public void TestEmptyHeaderRow()
+        {
+            var settings = new CSVSettings()
+            {
+                LineSeparator = "\n",
+                FieldDelimiter = ',',
+                HeaderRowIncluded = true
+            };
+
+            using (var cr = CSVReader.FromString("", settings))
+            {
+                Assert.AreEqual(0, cr.Headers.Length);
+                Assert.AreEqual(0, cr.Count());
+            }
+
+            using (var cr = CSVReader.FromString(" ", settings))
+            {
+                Assert.AreEqual(1, cr.Headers.Length);
+                Assert.AreEqual(" ", cr.Headers[0]);
+                Assert.AreEqual(0, cr.Count());
+            }
+
+            using (var cr = CSVReader.FromString("\t", settings))
+            {
+                Assert.AreEqual(1, cr.Headers.Length);
+                Assert.AreEqual("\t", cr.Headers[0]);
+                Assert.AreEqual(0, cr.Count());
+            }
+
+            using (var cr = CSVReader.FromString("\n", settings))
+            {
+                Assert.AreEqual(0, cr.Headers.Length);
+                Assert.AreEqual(0, cr.Count());
+            }
+
+            using (var cr = CSVReader.FromString(" \n", settings))
+            {
+                Assert.AreEqual(1, cr.Headers.Length);
+                Assert.AreEqual(" ", cr.Headers[0]);
+            }
+
+            using (var cr = CSVReader.FromString("\n ", settings))
+            {
+                Assert.AreEqual(0, cr.Headers.Length);
+                var lines = cr.ToArray();
+                Assert.AreEqual(1, lines.Length);
+                Assert.AreEqual(1, lines[0].Length);
+                Assert.AreEqual(" ", lines[0][0]);
+            }
+        }
+
+        [Test]
+        public void TestSepLineEmptyHeaderRow()
+        {
+            var settings = new CSVSettings()
+            {
+                LineSeparator = "\n",
+                FieldDelimiter = ',',
+                HeaderRowIncluded = true,
+                AllowSepLine = true
+            };
+
+            // if without an = sign, "sep" is just a header
+            using (var cr = CSVReader.FromString("sep", settings))
+            {
+                Assert.AreEqual(1, cr.Headers.Length);
+                Assert.AreEqual("sep", cr.Headers[0]);
+                Assert.AreEqual(0, cr.Count());
+            }
+
+            // if with an = sign but no character specified, then "sep=" is also treated as a header
+            // note that this is different from Excel's behaviour
+            // Excel interprets this as a field delimiter setter, but it doesn't set it to any character
+            // so all lines end up getting displayed in plaintext
+            using (var cr = CSVReader.FromString("sep=", settings))
+            {
+                Assert.AreEqual(1, cr.Headers.Length);
+                Assert.AreEqual("sep=", cr.Headers[0]);
+                Assert.AreEqual(0, cr.Count());
+            }
+
+            using (var cr = CSVReader.FromString("sep= ", settings))
+            {
+                Assert.AreEqual(1, cr.Headers.Length);
+                Assert.AreEqual("sep= ", cr.Headers[0]);
+                Assert.AreEqual(0, cr.Count());
+            }
+
+            using (var cr = CSVReader.FromString("sep = ", settings))
+            {
+                Assert.AreEqual(1, cr.Headers.Length);
+                Assert.AreEqual("sep = ", cr.Headers[0]);
+                Assert.AreEqual(0, cr.Count());
+            }
+
+            using (var cr = CSVReader.FromString("sep=;", settings))
+            {
+                Assert.AreEqual(0, cr.Headers.Length);
+                Assert.AreEqual(0, cr.Count());
+            }
+
+            using (var cr = CSVReader.FromString("sep=\n\nline1,line2", settings))
+            {
+                Assert.AreEqual(1, cr.Headers.Length);
+                Assert.AreEqual("sep=", cr.Headers[0]);
+                var lines = cr.ToArray();
+                Assert.AreEqual(2, lines.Length);
+                Assert.AreEqual(1, lines[0].Length);
+                Assert.AreEqual("", lines[0][0]);
+                Assert.AreEqual(2, lines[1].Length);
+                Assert.AreEqual("line1", lines[1][0]);
+                Assert.AreEqual("line2", lines[1][1]);
+            }
+
+            using (var cr = CSVReader.FromString("sep=;\n\nline1;line2", settings))
+            {
+                Assert.AreEqual(0, cr.Headers.Length);
+                var lines = cr.ToArray();
+                Assert.AreEqual(1, lines.Length);
+                Assert.AreEqual(2, lines[0].Length);
+                Assert.AreEqual("line1", lines[0][0]);
+                Assert.AreEqual("line2", lines[0][1]);
+            }
+
+            using (var cr = CSVReader.FromString("sep=\n", settings))
+            {
+                Assert.AreEqual(1, cr.Headers.Length);
+                Assert.AreEqual("sep=", cr.Headers[0]);
+                Assert.AreEqual(0, cr.Count());
+            }
+
+            using (var cr = CSVReader.FromString("sep=;\n", settings))
+            {
+                Assert.AreEqual(0, cr.Headers.Length);
+                Assert.AreEqual(0, cr.Count());
+            }
+        }
+
 #if HAS_ASYNC_IENUM
         [Test]
         public async Task TestAsyncReader()


### PR DESCRIPTION
The following code snippets, as well as a few other similar variants, throw a `NullReferenceException`. These simply represent valid but empty CSV files, so in my opinion should be allowed.
```c#
using CSVReader reader = CSVReader.FromString(string.Empty);
```
```c#
using CSVReader reader = CSVReader.FromString("sep=;");
```
I believe this bug was introduced with the sep feature, since if we imagine that code to not be there, there would be no `NullReferenceException`.

Also, the `CSVReader.Headers` property is often `null` when it actually should be an empty array, for example when inputting the following CSV:
```

1,2
```
Excel can open this file just fine, and simply displays `1` and `2` on the second row and across two columns, so it's perfectly valid CSV. Really, there are `0` headers here, rather than the concept of headers not existing altogether. So storing an empty array in the `Headers` property seems more appropriate, especially since this is precisely what a consumer will be expecting. Most consumers will just be iterating over the `Headers` array without doing any kind of null check (especially since in modern .NET, we don't expect a value to be `null` when it is not explicitly declared as a nullable `string[]?`).

The good news is that the fix for these is just a couple null checks and that's it, so this is a very tiny change. I've also added some more tests which check for these things. Without my change, these tests fail, but after my change, all tests (including existing ones) pass.