### PR TITLE
column split issues about doubled-up qualifier

### DIFF
--- a/src/CSVStateMachine.cs
+++ b/src/CSVStateMachine.cs
@@ -180,6 +180,18 @@ namespace CSVFile
                             return null;
                         }
 
+                        //If the line ends with a qualifier and we're not at the end of the stream,
+                        //it may be first qualifier from a doubled-up qualifier, so we should read the next chunk.
+                        if (p2 == _line.Length - 1)
+                        {
+                            if (!reachedEnd)
+                            {
+                                // Backtrack one character so we can move forward when the next chunk loads
+                                _position--;
+                                return null;
+                            }
+                        }
+
                         // Append the text between the qualifiers
                         _work.Append(_line.Substring(_position + 1, p2 - _position - 1));
                         _position = p2;


### PR DESCRIPTION
Our CSV file has a column that contains JSON-formatted data, so it includes many doubled-up qualifier. We found that sometimes the fields are not split correctly.
During debugging, we found that when reading a chunk, if the read ends just before first qualifier of a doubled-up qualifier in json data, it causes an error.

Therefore, if the last character of a line is a qualifier and there is not end of stream, it should continue reading the next chunk.

`internal class Program
{
    static void Main(string[] args)
    {
        var settings = new CSVSettings()
        {
            HeaderRowIncluded = true,
            BufferSize = 119,
            HeadersCaseSensitive = false
        };

        string csvFile = "sample.csv";

        using (var csv = CSVReader.FromFile(csvFile, settings))
        {
            foreach (var line in csv.Lines())
            {
                Console.WriteLine(line[7]);
            }
        }
    }
}
[sample.csv](https://github.com/user-attachments/files/24022189/sample.csv)
`